### PR TITLE
Fix BLE stability: auto-restart btmon and re-advertise on disconnect

### DIFF
--- a/ble/moonboard_ble_service.py
+++ b/ble/moonboard_ble_service.py
@@ -9,6 +9,8 @@ from moonboard_app_protocol import UnstuffSequence, decode_problem_string
 import paho.mqtt.client as mqtt
 
 import os
+import errno
+import time
 import threading
 import pty
  
@@ -117,22 +119,76 @@ class MoonboardBLE():
             unstuffer.flags = ''
             self.start_adv(logger)
 
-    def monitor_btmon(self, logger, unstuffer): 
-        out_r, out_w = pty.openpty()
-        cmd = ["sudo","btmon"]
-        process = subprocess.Popen(cmd, stdout=out_w)
-        f = OutStream(out_r)
+    def monitor_btmon(self, logger, unstuffer):
+        restart_delay = 2
+        max_restart_delay = 30
+
         while True:
-            lines, readable = f.read_lines()
-            if not readable: break
-            for line in lines:                
-                if line != '':
-                    line = line.decode()
-                    if 'Data:' in line:
-                        data = line.replace(' ','').replace('\x1b','').replace('[0m','').replace('Data:','')
-                        self.process_rx(unstuffer,logger,data)
-                        t1 = bytearray.fromhex(data).decode(errors="ignore")
-                        logger.info('New data '+ data+ 'and decoded '+t1)
+            out_r, out_w = pty.openpty()
+            cmd = ["sudo", "btmon"]
+            try:
+                process = subprocess.Popen(cmd, stdout=out_w)
+                logger.info('btmon started (pid %d)', process.pid)
+            except Exception as e:
+                logger.error('Failed to start btmon: ' + str(e))
+                os.close(out_r)
+                os.close(out_w)
+                time.sleep(restart_delay)
+                restart_delay = min(restart_delay * 2, max_restart_delay)
+                continue
+
+            f = OutStream(out_r)
+            restart_delay = 2  # reset backoff on successful start
+
+            try:
+                while True:
+                    lines, readable = f.read_lines()
+                    if not readable:
+                        break
+                    for line in lines:
+                        if line != b'':
+                            try:
+                                line = line.decode(errors='ignore')
+                            except Exception:
+                                continue
+                            if 'Disconnect Complete' in line:
+                                logger.info('Client disconnected, restarting advertising...')
+                                try:
+                                    self.setup_adv(logger)
+                                    self.start_adv(logger)
+                                    logger.info('Advertising restarted successfully')
+                                except Exception as e:
+                                    logger.error('Failed to restart advertising: ' + str(e))
+                            elif 'Data:' in line:
+                                data = line.replace(' ','').replace('\x1b','').replace('[0m','').replace('Data:','')
+                                self.process_rx(unstuffer, logger, data)
+                                t1 = bytearray.fromhex(data).decode(errors="ignore")
+                                logger.info('New data '+ data + ' and decoded ' + t1)
+            except Exception as e:
+                logger.error('btmon monitoring error: ' + str(e))
+
+            # Cleanup
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except Exception:
+                try:
+                    process.kill()
+                    process.wait(timeout=5)
+                except Exception:
+                    pass
+            try:
+                os.close(out_r)
+            except OSError:
+                pass
+            try:
+                os.close(out_w)
+            except OSError:
+                pass
+
+            logger.warning('btmon exited, restarting in %ds...', restart_delay)
+            time.sleep(restart_delay)
+            restart_delay = min(restart_delay * 2, max_restart_delay)
 
 
     def main(self,logger,adapter):


### PR DESCRIPTION
Two critical issues caused the need for manual restarts:

1. btmon subprocess was never restarted when it exited - the service
   kept running but silently stopped receiving BLE data. Now btmon is
   monitored in a loop with exponential backoff (2s-30s) and
   automatically restarted on exit.

2. After an iPhone disconnected, BLE advertising was never restarted,
   making the Moonboard invisible for reconnection. Now "Disconnect
   Complete" events from btmon are detected and advertising is
   automatically re-setup and started.

Also fixes: proper fd cleanup, decode error handling, daemon thread.

https://claude.ai/code/session_01ARBx1xkrRnWGBYsSb3y4Zg